### PR TITLE
fix(ui): fixed overflowing background and padding in Customize Now button

### DIFF
--- a/client/src/components/Guide/guide.jsx
+++ b/client/src/components/Guide/guide.jsx
@@ -56,9 +56,9 @@ const Guide = () => {
                     </div>
                 </div>
             </div>
-            <div className="mt-[40px] shadow-[2px_4px_35px_4px_rgba(0,0,0,0.10)] rounded-2xl">
+            <div className="mt-[40px] shadow-[2px_4px_35px_4px_rgba(0,0,0,0.10)] rounded-full">
                 <Link to="/customize">
-                    <button className="inline-block bg-black text-white rounded-full border-2 border-black px-5 pb-[8px] pt-3 text-[25px] font-medium leading-normal transition duration-150 ease-in-out hover:bg-white hover:text-black focus:border-neutral-800 focus:text-neutral-800 focus:outline-none focus:ring-0 active:border-neutral-900 active:text-neutral-900 max-lg:text-[14px] hover:border-black">
+                    <button className="inline-block bg-black text-white rounded-full border-2 border-black px-5 py-3 text-[25px] font-medium leading-normal transition duration-150 ease-in-out hover:bg-white hover:text-black focus:border-neutral-800 focus:text-neutral-800 focus:outline-none focus:ring-0 active:border-neutral-900 active:text-neutral-900 max-lg:text-[14px] hover:border-black">
                         Customize Now!
                     </button>
                 </Link>


### PR DESCRIPTION
## Description

Fixed the white overflowing background and padding in the "Customize Now" button. 

### Changes

Changed the border radius of background \<div\> for fixing background issue. Added uniform padding along y to fix asymmetrical position of text within button.

## Screenshots
Non-hovered state:
<img width="664" alt="Screenshot 2024-05-17 at 11 40 25 AM" src="https://github.com/dvjsharma/Drawn2Shoe/assets/77493105/d89da266-5095-4230-9bec-58dda008d7d8">
Hovered state:
<img width="664" alt="Screenshot 2024-05-17 at 11 40 30 AM" src="https://github.com/dvjsharma/Drawn2Shoe/assets/77493105/99569e1c-b860-443e-902d-0e1cb85cc01b">


Closes #48 