### PR TITLE
fix(ui): removed the arrows in Pincode number input box

### DIFF
--- a/client/src/pages/Signup/signup.jsx
+++ b/client/src/pages/Signup/signup.jsx
@@ -232,7 +232,7 @@ const Signup = () => {
                             </div>
                             <div className="relative mt-3">
                                 <input
-                                    className="appearance-none border pl-12 border-gray-100 shadow-sm focus:shadow-md focus:placeholder-gray-600  transition  rounded-md w-full py-3 text-gray-600 leading-tight focus:outline-none focus:ring-gray-600 focus:shadow-outline"
+                                    className="appearance-none border pl-12 border-gray-100 shadow-sm focus:shadow-md focus:placeholder-gray-600  transition  rounded-md w-full py-3 text-gray-600 leading-tight focus:outline-none focus:ring-gray-600 focus:shadow-outline [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                                     id="password"
                                     type="number"
                                     placeholder="Pincode"


### PR DESCRIPTION
## Description

Removed the default arrows which were appearing in input box for Pincode.

## Changes

Added appearance none for the arrows in the class corresponding to the input box.

## Screenshots
<img width="741" alt="fixed" src="https://github.com/dvjsharma/Drawn2Shoe/assets/77493105/b5fb230d-7c2f-40c9-9886-846a30e93144">


Closes #54 
