### PR TITLE
Feature for auto commenting on issue and PRs

### DIFF
--- a/.github/workflows/closed-issue.yml
+++ b/.github/workflows/closed-issue.yml
@@ -1,0 +1,22 @@
+name: Close issue comment
+on:
+  issues:
+    types:
+      - closed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Issue close
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo, number } = context.issue;
+            const commentauthor = context.payload.issue.user.login;
+            const commentBody = `Hey @${commentauthor} ! Just wanted to inform you that the issue has been closed\nWould like to see you again.`;
+            
+            await github.issues.createComment({ owner, repo, issue_number: number, body: commentBody });
+            console.log(`Commented on the issue: ${commentBody}.`);

--- a/.github/workflows/closed-pr.yml
+++ b/.github/workflows/closed-pr.yml
@@ -1,0 +1,41 @@
+name: Comment on PR Closure
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR Merge Status
+        id: pr_status
+        run: echo "::set-output name=merged::${{ github.event.pull_request.merged }}"
+
+      - name: Comment on PR Closure
+        if: steps.pr_status.outputs.merged == 'true'
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo, number } = context.issue;
+            const commentAuthor = context.payload.pull_request.user.login;
+            const commentBody = `Hey @${ commentAuthor } Super Happy to inform you that your PR has been merged!!!!!!\nWould like to see you again super soon.`;
+            await github.issues.createComment({ owner, repo, issue_number: number, body: commentBody });
+            console.log(`Commented on the closed PR: ${commentBody}.`);
+        
+      - name: Comment on PR Closure
+        if: steps.pr_status.outputs.merged != 'true'
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo, number } = context.issue;
+            const commentAuthor = context.payload.pull_request.user.login;
+            const commentBody = `Hey @${ commentAuthor } ,Wanted to let you know that we have decided to close your pull request.
+            In case of any issues, you can contact me.
+            Thank you!`;
+            await github.issues.createComment({ owner, repo, issue_number: number, body: commentBody });
+            console.log(`Commented on the closed PR: ${commentBody}.`);

--- a/.github/workflows/issue-comment.yml
+++ b/.github/workflows/issue-comment.yml
@@ -1,0 +1,23 @@
+name: Comment on opening issue!
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Issue Opened
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo, number } = context.issue;
+            const commentauthor = context.payload.issue.user.login;
+            const commentBody = `Hello @${commentauthor} Thank you for creating a new issue! 🎉 Your issue is currently under review.\nIf you would like to assign this issue to yourself, please comment with the word "self" and the issue will be assigned to you.`;
+
+            await github.issues.createComment({ owner, repo, issue_number: number, body: commentBody });
+            console.log(`Commented on the issue: ${commentBody}.`);
+

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,22 @@
+name: Pull Request related comments
+on:
+  pull_request_target:
+    types:
+      - opened
+  
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on Opening Pull Request
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const {owner, repo, number} = context.issue;
+            const commentAuthor = context.payload.sender.login;
+            const commentBody = `Hey @${ commentAuthor }, Thank you for creating PR! Will review it super soon.
+            Don’t forget to ⭐ the repository!
+            Will see you soon!`;
+            await github.issues.createComment({owner, repo, issue_number : number, body: commentBody});
+            console.log('Commented on PR');


### PR DESCRIPTION
## Description

I would like an automated feature that posts a predefined comment on an issue as soon as it is created. This feature aims to address the problem of delayed and inconsistent communication following the creation of issues. By automatically commenting on issues as soon as they are created, it ensures that contributors receive immediate feedback and acknowledgment for their efforts. This fosters a positive and supportive environment for collaboration, encouraging continued participation and engagement from contributors.

### Changes

I have added 4 different files and it'll auto comment when an issue is closed/opened and will also comment when an PR is opened/closed/merged.

## How to test

You can raise an issue and create a PR and test is by merging and closing and closing without merging.

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)